### PR TITLE
Change safety message

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required(VERSION 3.0)
 project(swd_ros_controllers)
 
 if(NOT DEFINED PRJ_VERSION)
-  set(PRJ_VERSION "1.2.1")
+  set(PRJ_VERSION "2.0.0")
 endif(NOT DEFINED PRJ_VERSION)
 
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Header header
 bool safe_torque_off
 bool safe_brake_control
 bool safety_limited_speed
-bool safe_direction_indication_pos
-bool safe_direction_indication_neg
+bool safe_direction_indication_forward
+bool safe_direction_indication_backward
 ```
 
 ## Support

--- a/msg/SafetyFunctions.msg
+++ b/msg/SafetyFunctions.msg
@@ -2,5 +2,5 @@ Header header
 bool safe_torque_off
 bool safe_brake_control
 bool safety_limited_speed
-bool safe_direction_indication_pos
-bool safe_direction_indication_neg
+bool safe_direction_indication_forward
+bool safe_direction_indication_backward

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>swd_ros_controllers</name>
-  <version>1.2.1</version>
+  <version>2.0.0</version>
   <description>Package which control 2 wheels in as a differential drive robot</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->
@@ -14,19 +14,19 @@
   <!-- One license tag required, multiple allowed, one license per tag -->
   <!-- Commonly used license strings: -->
   <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>EZW_EULA</license>
+  <license>LGPLv2.1</license>
 
 
   <!-- Url tags are optional, but multiple are allowed, one per tag -->
   <!-- Optional attribute type can be: website, bugtracker, or repository -->
   <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/ezw_ros_controllers</url> -->
+  <!-- <url type="website">http://wiki.ros.org/swd_ros_controllers</url> -->
 
 
   <!-- Author tags are optional, multiple are allowed, one per tag -->
   <!-- Authors do not have to be maintainers, but could be -->
   <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+  <author email="a.bougouffa@ez-wheel.com">Abdelhak BOUGOUFFA</author>
 
 
   <!-- The *depend tags are used to specify dependencies -->

--- a/src/diff_drive_controller/DiffDriveController.cpp
+++ b/src/diff_drive_controller/DiffDriveController.cpp
@@ -605,18 +605,18 @@ namespace ezw
 
             err = m_left_controller.getSafetyControlWord(ezw::smccore::Controller::SafetyControlWordId::SAFEIN_1, res);
 
-            msg.safe_torque_off               = res.safety_function_2 && res.safety_function_3;
-            msg.safe_direction_indication_pos = res.safety_function_2 && res.safety_function_3;
-            msg.safety_limited_speed          = res.safety_function_4 && res.safety_function_5;
+            msg.safe_torque_off                   = res.safety_function_2 && res.safety_function_3;
+            msg.safe_direction_indication_forward = res.safety_function_2 && res.safety_function_3;
+            msg.safety_limited_speed              = res.safety_function_4 && res.safety_function_5;
 
 #if VERBOSE_OUTPUT
-            ROS_INFO("STO: %d, SDI+: %d, SLS: %d", msg.safe_torque_off, msg.safe_direction_indication_pos, msg.safety_limited_speed);
+            ROS_INFO("STO: %d, SDI+: %d, SLS: %d", msg.safe_torque_off, msg.safe_direction_indication_forward, msg.safety_limited_speed);
 #endif
 
             m_pub_safety.publish(msg);
 #else
             if (m_nmt_ok) {
-                msg.header.stamp = ros::Time::now();
+                msg.header.stamp    = ros::Time::now();
                 msg.header.frame_id = m_base_frame;
 
                 // Reading SBC
@@ -700,8 +700,8 @@ namespace ezw
                     sdi_n = !(sdi_l_p || sdi_r_n);
                 }
 
-                msg.safe_direction_indication_pos = sdi_p;
-                msg.safe_direction_indication_neg = sdi_n;
+                msg.safe_direction_indication_forward  = sdi_p;
+                msg.safe_direction_indication_backward = sdi_n;
 
                 // Reading SLS
                 err = m_left_controller.getSafetyFunctionCommand(ezw::smccore::Controller::SafetyFunctionId::SLS_1, res_l);
@@ -721,7 +721,7 @@ namespace ezw
                 msg.safety_limited_speed = !(res_r || res_l);
 
 #if VERBOSE_OUTPUT
-                ROS_INFO("STO: %d, SDI+: %d, SLS: %d", msg.safe_torque_off, msg.safe_direction_indication_pos, msg.safety_limited_speed);
+                ROS_INFO("STO: %d, SDI+: %d, SLS: %d", msg.safe_torque_off, msg.safe_direction_indication_forward, msg.safety_limited_speed);
 #endif
 
                 m_safety_msg_mtx.lock();


### PR DESCRIPTION
- Change `safety/safe_direction_indication_pos` to `safety/safe_direction_indication_forward` 
- Change `safety/safe_direction_indication_neg` to `safety/safe_direction_indication_backward` 
- Change version to 2.0.0 (backward incompatible)

Signed-off-by: Abdelhak Bougouffa <a.bougouffa@ez-wheel.com>